### PR TITLE
[security] Upgrade vulnerable dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,12 +45,14 @@
     <testRetryCount>2</testRetryCount>
 
     <!-- connector dependencies -->
-    <jackson.version>2.9.7</jackson.version>
+    <jackson.version>2.13.2</jackson.version>
     <lombok.version>1.18.20</lombok.version>
     <pulsar.version>2.8.0.8</pulsar.version>
     <google-cloud.version>20.9.0</google-cloud.version>
     <avro.version>1.10.2</avro.version>
     <protobuf.version>3.17.3</protobuf.version>
+    <commons-compress.version>1.21</commons-compress.version>
+    <gson.version>2.8.9</gson.version>
 
     <!-- test dependencies -->
     <junit.version>4.12</junit.version>
@@ -116,6 +118,18 @@
         <groupId>org.apache.avro</groupId>
         <artifactId>avro</artifactId>
         <version>${avro.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+        <version>${commons-compress.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.code.gson</groupId>
+        <artifactId>gson</artifactId>
+        <version>${gson.version}</version>
       </dependency>
 
       <!-- test dependencies -->


### PR DESCRIPTION
### Motivation
There are a couple of vulnerable dependencies with CVE with critical severity.
* jackson-databind
* gson
* commons-compress

### Modifications

* Upgrade to non vulnerable versions

jackson: 2.9.7 to 2.13.2
gson: 2.8.7 to 2.8.9
commons-compress: 1.20 to 1.21
