### PR TITLE
[security] Upgrade jackson-databind to get rid of CVE-2020-36518

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <testRetryCount>2</testRetryCount>
 
     <!-- connector dependencies -->
-    <jackson.version>2.13.2</jackson.version>
+    <jackson-databind.version>2.13.2.1</jackson-databind.version>
     <lombok.version>1.18.20</lombok.version>
     <pulsar.version>2.8.0.8</pulsar.version>
     <google-cloud.version>20.9.0</google-cloud.version>
@@ -89,7 +89,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${jackson.version}</version>
+        <version>${jackson-databind.version}</version>
       </dependency>
       <dependency>
         <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
See Pulsar related pull https://github.com/apache/pulsar/pull/14871
- [x] `no-need-doc` 
  
  