### PR TITLE
fix: use generic object instead of generic record

### DIFF
--- a/src/main/java/org/apache/pulsar/ecosystem/io/pubsub/PubsubRecord.java
+++ b/src/main/java/org/apache/pulsar/ecosystem/io/pubsub/PubsubRecord.java
@@ -18,11 +18,11 @@
  */
 package org.apache.pulsar.ecosystem.io.pubsub;
 
-
 import com.google.pubsub.v1.PubsubMessage;
 import java.util.Map;
 import java.util.Optional;
 import lombok.Data;
+import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.functions.api.Record;
 
 /**
@@ -65,5 +65,10 @@ public class PubsubRecord implements Record<byte[]> {
     @Override
     public Optional<String> getDestinationTopic() {
         return Optional.of(this.destination);
+    }
+
+    @Override
+    public Schema<byte[]> getSchema() {
+        return Schema.BYTES;
     }
 }

--- a/src/main/java/org/apache/pulsar/ecosystem/io/pubsub/PubsubSink.java
+++ b/src/main/java/org/apache/pulsar/ecosystem/io/pubsub/PubsubSink.java
@@ -23,7 +23,7 @@ import com.google.protobuf.DynamicMessage;
 import java.io.ByteArrayOutputStream;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.GenericObject;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.core.Sink;
 import org.apache.pulsar.io.core.SinkContext;
@@ -32,7 +32,7 @@ import org.apache.pulsar.io.core.SinkContext;
  * PubsubSink feed data from Pulsar into Google Cloud Pub/Sub.
  */
 @Slf4j
-public class PubsubSink extends PubsubConnector implements Sink<GenericRecord> {
+public class PubsubSink extends PubsubConnector implements Sink<GenericObject> {
     private SinkContext sinkContext;
     private PubsubPublisher publisher;
     private static final String METRICS_TOTAL_SUCCESS = "_pubsub_sink_total_success_";
@@ -46,7 +46,7 @@ public class PubsubSink extends PubsubConnector implements Sink<GenericRecord> {
     }
 
     @Override
-    public void write(Record<GenericRecord> record) throws Exception {
+    public void write(Record<GenericObject> record) throws Exception {
         Object data = null;
         if (record.getSchema() == null) {
             if (record.getMessage().isPresent()) {
@@ -89,14 +89,14 @@ public class PubsubSink extends PubsubConnector implements Sink<GenericRecord> {
         });
     }
 
-    private void success(Record<GenericRecord> record) {
+    private void success(Record<GenericObject> record) {
         record.ack();
         if (sinkContext != null) {
             sinkContext.recordMetric(METRICS_TOTAL_SUCCESS, 1);
         }
     }
 
-    private void fail(Record<GenericRecord> record) {
+    private void fail(Record<GenericObject> record) {
         record.fail();
         if (sinkContext != null) {
             sinkContext.recordMetric(METRICS_TOTAL_FAILURE, 1);


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation

From https://github.com/apache/pulsar/pull/10057.

The `GenericObject` is high-level interface that is easier than `GenericRecord`,  which extends the `GenericObject` interface, so we can use the `GenericObject` interface. 

### Modifications

Use GenericObject instead of GenericRecord.

### Documentation

- [x] `no-need-doc` 


