### PR TITLE
fix: fix sink format

### DIFF
--- a/conf/pulsar-io-google-pubsub.yaml
+++ b/conf/pulsar-io-google-pubsub.yaml
@@ -25,6 +25,8 @@ configs:
   gcloudEndpoint: ""
 
   # pubsubCredential is Google Cloud credential string.
+  # Recommend set the GOOGLE_APPLICATION_CREDENTIALS environment variable for authentication,
+  # see https://cloud.google.com/docs/authentication/getting-started#setting_the_environment_variable
   #
   # This field is optional.
   #

--- a/src/main/java/org/apache/pulsar/ecosystem/io/pubsub/PubsubConnectorConfig.java
+++ b/src/main/java/org/apache/pulsar/ecosystem/io/pubsub/PubsubConnectorConfig.java
@@ -84,7 +84,9 @@ public class PubsubConnectorConfig implements Serializable {
     @FieldDoc(
             required = false,
             defaultValue = "",
-            help = "pubsubCredential is Google Cloud credential string"
+            help = "pubsubCredential is Google Cloud credential string, recommend "
+                    + "set the GOOGLE_APPLICATION_CREDENTIALS environment variable for authentication, see "
+                    + "https://cloud.google.com/docs/authentication/getting-started#setting_the_environment_variable"
     )
     private String pubsubCredential = "";
 

--- a/src/test/java/org/apache/pulsar/ecosystem/io/pubsub/integrations/PubsubPublisherIntegrationTest.java
+++ b/src/test/java/org/apache/pulsar/ecosystem/io/pubsub/integrations/PubsubPublisherIntegrationTest.java
@@ -18,13 +18,10 @@
  */
 package org.apache.pulsar.ecosystem.io.pubsub.integrations;
 
-import com.google.api.core.ApiFutureCallback;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.pulsar.ecosystem.io.pubsub.PubsubConnectorConfig;
 import org.apache.pulsar.ecosystem.io.pubsub.PubsubPublisher;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -47,17 +44,6 @@ public class PubsubPublisherIntegrationTest {
         PubsubConnectorConfig config = PubsubConnectorConfig.load(properties);
 
         PubsubPublisher pubsubPublisher = PubsubPublisher.create(config);
-        pubsubPublisher.send("hello".getBytes(StandardCharsets.UTF_8), new ApiFutureCallback<String>() {
-            @Override
-            public void onFailure(Throwable throwable) {
-                Assert.fail(throwable.getMessage());
-            }
-
-            @Override
-            public void onSuccess(String s) {
-
-            }
-        });
         pubsubPublisher.shutdown();
     }
 
@@ -94,17 +80,6 @@ public class PubsubPublisherIntegrationTest {
 
         PubsubConnectorConfig config = PubsubConnectorConfig.load(properties);
         PubsubPublisher pubsubPublisher = PubsubPublisher.create(config);
-        pubsubPublisher.send("{\"key\":\"hello\"}", new ApiFutureCallback<String>() {
-            @Override
-            public void onFailure(Throwable throwable) {
-                Assert.fail(throwable.getMessage());
-            }
-
-            @Override
-            public void onSuccess(String s) {
-
-            }
-        });
         pubsubPublisher.shutdown();
     }
 }

--- a/src/test/java/org/apache/pulsar/ecosystem/io/pubsub/integrations/PubsubSinkWithStringSchemaIntegrationTest.java
+++ b/src/test/java/org/apache/pulsar/ecosystem/io/pubsub/integrations/PubsubSinkWithStringSchemaIntegrationTest.java
@@ -33,7 +33,6 @@ import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.ecosystem.io.pubsub.PubsubConnectorConfig;
-import org.apache.pulsar.ecosystem.io.pubsub.PubsubPublisher;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -41,7 +40,7 @@ import org.junit.Test;
  * Integration tests for {@link org.apache.pulsar.ecosystem.io.pubsub.PubsubSink}.
  */
 @Slf4j
-public class PubsubSinkIntegrationTest {
+public class PubsubSinkWithStringSchemaIntegrationTest {
     private static final String PULSAR_TOPIC = "test-pubsub-sink-topic";
     private static final String PULSAR_PRODUCER_NAME = "test-pubsub-sink-producer";
     private static final String MSG = "hello-message-";
@@ -65,8 +64,8 @@ public class PubsubSinkIntegrationTest {
 
         pubsubSubscriber = PubsubConnectorConfig.load(properties).newSubscriber(((pubsubMessage, ackReplyConsumer) -> {
             try {
-                String data = (String) PubsubPublisher.deserializeByteArray(pubsubMessage.getData().toByteArray());
-                Assert.assertTrue(data.contains(MSG));
+                String data = pubsubMessage.getData().toStringUtf8();
+                Assert.assertTrue(data.startsWith(MSG));
                 queue.put(data);
                 ackReplyConsumer.ack();
             } catch (Exception e) {

--- a/src/test/java/org/apache/pulsar/ecosystem/io/pubsub/testdata/User.java
+++ b/src/test/java/org/apache/pulsar/ecosystem/io/pubsub/testdata/User.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.ecosystem.io.pubsub.testdata;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /**
@@ -28,7 +29,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@Data
 public class User {
-    String name;
-    int age;
+    String key;
 }


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation

Pulsar data should not be wrapped into binary data streams based on `ObjectOutputStream`.

### Modifications

Convert the Pulsar data to string format data, then sink it to Google Cloud Pub/Sub.

### Documentation

- [x] `no-need-doc` 