### PR TITLE
Add pubsubSubscriptionId as a config option

### DIFF
--- a/docs/google-pubsub-source.md
+++ b/docs/google-pubsub-source.md
@@ -58,6 +58,7 @@ Before using the Google Cloud Pub/Sub source connector, you need to configure it
 | `pubsubSchemaType` | String | false | "" (empty string) | The schema type. You must set the schema type when creating a schema for Google Cloud Pub/Sub topics. Currently, only the AVRO format is supported. |
 | `pubsubSchemaEncoding` | String | false | "" (empty string) | The encoding of the schema. You must set the schema encoding when creating a schema for Google Cloud Pub/Sub topics. Currently, only the JSON format is supported.|
 | `pubsubSchemaDefinition` | String | false | "" (empty string) |  The definition of the schema. It is used to create a schema to or parse messages from Google Cloud Pub/Sub topics. |
+| `pubsubSubscriptionId` | String | false | pubsubTopicId | The name of the subscription on pubsub. If not set, the pubsub topic name is used as the subscription name. |
 
 > **Note**
 >

--- a/src/main/java/org/apache/pulsar/ecosystem/io/pubsub/PubsubConnectorConfig.java
+++ b/src/main/java/org/apache/pulsar/ecosystem/io/pubsub/PubsubConnectorConfig.java
@@ -123,6 +123,14 @@ public class PubsubConnectorConfig implements Serializable {
     )
     private String pubsubSchemaDefinition = "";
 
+    @FieldDoc(
+            required = false,
+            defaultValue = "",
+            help = "pubsubSubscriptionId is used to set pubsub subscription name. If not set, it defaults"
+                    + "to the pubsub topic name"
+    )
+    private String pubsubSubscriptionId = null;
+
     private transient TransportChannelProvider transportChannelProvider = null;
     private transient CredentialsProvider credentialsProvider = null;
 
@@ -140,6 +148,10 @@ public class PubsubConnectorConfig implements Serializable {
                 PubsubConnectorConfig.class);
         pubsubConnectorConfig.transportChannelProvider = pubsubConnectorConfig.newTransportChannelProvider();
         pubsubConnectorConfig.credentialsProvider = pubsubConnectorConfig.newCredentialsProvider();
+        // Uses topic name as subscription by default.
+        if (pubsubConnectorConfig.pubsubSubscriptionId == null) {
+            pubsubConnectorConfig.pubsubSubscriptionId = pubsubConnectorConfig.pubsubTopicId;
+        }
         return pubsubConnectorConfig;
     }
 
@@ -201,7 +213,7 @@ public class PubsubConnectorConfig implements Serializable {
     }
 
     public Subscriber newSubscriber(MessageReceiver receiver) throws IOException {
-        ProjectSubscriptionName subscriptionName = ProjectSubscriptionName.of(pubsubProjectId, pubsubTopicId);
+        ProjectSubscriptionName subscriptionName = ProjectSubscriptionName.of(pubsubProjectId, pubsubSubscriptionId);
 
         SubscriptionAdminSettings subscriptionAdminSettings =
                 SubscriptionAdminSettings.newBuilder()

--- a/src/test/java/org/apache/pulsar/ecosystem/io/pubsub/PubsubConnectorTest.java
+++ b/src/test/java/org/apache/pulsar/ecosystem/io/pubsub/PubsubConnectorTest.java
@@ -61,6 +61,7 @@ public class PubsubConnectorTest {
                 + "   }\n"
                 + " ]\n"
                 + "}";
+        String subscriptionId = "test-pubsub-subscription-" + System.currentTimeMillis();
 
         Map<String, Object> properties = new HashMap<>();
         properties.put("pubsubEndpoint", endpoint);
@@ -71,6 +72,7 @@ public class PubsubConnectorTest {
         properties.put("pubsubSchemaType", schemaType);
         properties.put("pubsubSchemaEncoding", schemaEncoding);
         properties.put("pubsubSchemaDefinition", schemaDefinition);
+        properties.put("pubsubSubscriptionId", subscriptionId);
 
         PubsubConnector connector = new PubsubConnector();
         connector.initialize(properties);
@@ -85,5 +87,6 @@ public class PubsubConnectorTest {
         assertEquals(schemaType, connector.getConfig().getPubsubSchemaType().toString());
         assertEquals(schemaEncoding, connector.getConfig().getPubsubSchemaEncoding().toString());
         assertEquals(schemaDefinition, connector.getConfig().getPubsubSchemaDefinition());
+        assertEquals(subscriptionId, connector.getConfig().getPubsubSubscriptionId());
     }
 }


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes #341 

### Motivation

The existing code uses pubsub topic name as pubsub subscription name. That name may already be used. Even if not already used, it means that only one source can be deployed per pubsub topic globally.

### Modifications

Added a config option `pubsubSubscriptionId`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - *Extended unit test to cover the additional option*

### Documentation

- [X]  Added to google-pubsub-source.md